### PR TITLE
Feature: Subscription Plan End of Life

### DIFF
--- a/contracts/interfaces/ICaskSubscriptionPlans.sol
+++ b/contracts/interfaces/ICaskSubscriptionPlans.sol
@@ -6,7 +6,8 @@ interface ICaskSubscriptionPlans {
     enum PlanStatus {
         None,
         Enabled,
-        Disabled
+        Disabled,
+        EndOfLife
     }
 
     struct Plan {
@@ -56,6 +57,8 @@ interface ICaskSubscriptionPlans {
 
     function enableSubscriptionPlan(bytes32 _planId) external;
 
+    function eolSubscriptionPlan(bytes32 _planId) external;
+
     function verifyDiscount(bytes32 _planId, bytes32 _discountProof) external view returns(bytes32);
 
     function getSubscriptionPlans(address _provider) external view returns(bytes32[] memory);
@@ -83,5 +86,8 @@ interface ICaskSubscriptionPlans {
 
     /** @dev Emitted when `provider` enables a subscription plan */
     event SubscriptionPlanEnabled(address indexed provider, bytes32 indexed planId, bytes32 indexed planCode);
+
+    /** @dev Emitted when `provider` end-of-lifes a subscription plan */
+    event SubscriptionPlanEOL(address indexed provider, bytes32 indexed planId, bytes32 indexed planCode);
 
 }

--- a/contracts/interfaces/ICaskSubscriptions.sol
+++ b/contracts/interfaces/ICaskSubscriptions.sol
@@ -10,8 +10,7 @@ interface ICaskSubscriptions {
         Paused,
         Canceled,
         PendingCancel,
-        PastDue,
-        Invalid
+        PastDue
     }
 
     struct Subscription {

--- a/contracts/protocol/CaskSubscriptions.sol
+++ b/contracts/protocol/CaskSubscriptions.sol
@@ -393,7 +393,8 @@ KeeperCompatibleInterface
 
         // subscription scheduled to be canceled by consumer or has hit its cancelAt time
         if (subscription.status == SubscriptionStatus.PendingCancel ||
-            (subscription.cancelAt > 0 && subscription.cancelAt <= uint32(block.timestamp))) {
+            (subscription.cancelAt > 0 && subscription.cancelAt <= uint32(block.timestamp)) ||
+            plan.status == ICaskSubscriptionPlans.PlanStatus.EndOfLife) {
 
             subscription.status = SubscriptionStatus.Canceled;
             providerActiveSubscriptionCount[subscription.provider] =


### PR DESCRIPTION
* Provider can mark a subscription plan as EOL and any active subscriptions on that plan will automatically cancel at their next renewal date. This action is irreversible.